### PR TITLE
Refactor remote functions

### DIFF
--- a/src/ray_tpu.py
+++ b/src/ray_tpu.py
@@ -74,7 +74,11 @@ class RayTpuManager:
         )
     return tpu_info
 
-  def reserve(self, topology_id, count):
+  def reserve(
+      self,
+      topology_id: str,
+      count: int,
+      timeout: Optional[int] = 600):
     """
     This is a hacky way to reserve the topology. It utilizes Ray's
     existing ability to autoscale based on the "TPU-X-head" syntax
@@ -108,7 +112,6 @@ class RayTpuManager:
       tpu_info: List[Any],
       multislice = False,
       env: Optional[Mapping[str, Any]] = None,
-      timeout: Optional[int] = 600,
       *args,
       **kwargs,
   ) -> List[Union[ray.actor.ActorHandle, ray._raylet.ObjectRef]]:
@@ -160,7 +163,6 @@ class RayTpuManager:
       tpu_info: List[Any],
       multislice = False,
       env: Optional[Mapping[str, Any]] = None,
-      timeout: Optional[int] = 600,
       *args,
       **kwargs,
   ) -> List[Union[ray.actor.ActorHandle, ray._raylet.ObjectRef]]:
@@ -209,7 +211,7 @@ class RayTpuManager:
     # topology_id is in the form "{generation}-{cores}".
     # count is how many instances of each topology to create.
 
-    tpu_info = self.reserve(topology_id, count)
+    tpu_info = self.reserve(topology_id, count, timeout)
       
     time.sleep(1)
 
@@ -222,7 +224,6 @@ class RayTpuManager:
           tpu_info,
           multislice,
           env,
-          timeout,
           args,
           kwargs)
     else:
@@ -231,7 +232,6 @@ class RayTpuManager:
           tpu_info,
           multislice,
           env,
-          timeout,
           args,
           kwargs)        
 

--- a/src/ray_tpu.py
+++ b/src/ray_tpu.py
@@ -228,8 +228,8 @@ class RayTpuManager:
           tpu_info,
           multislice,
           env,
-          args,
-          kwargs)
+          *args,
+          **kwargs)
     else:
         return self._remote_host_mode(
           topology_id,
@@ -237,8 +237,8 @@ class RayTpuManager:
           tpu_info,
           multislice,
           env,
-          args,
-          kwargs)        
+          *args,
+          **kwargs)        
 
 
 _manager = RayTpuManager()

--- a/src/ray_tpu.py
+++ b/src/ray_tpu.py
@@ -108,6 +108,7 @@ class RayTpuManager:
 
   def _remote_host_mode(
       self,
+      topology_id: str,
       actor_or_fn: Union[ray.actor.ActorClass, Type],
       tpu_info: List[Any],
       multislice = False,
@@ -115,12 +116,13 @@ class RayTpuManager:
       *args,
       **kwargs,
   ) -> List[Union[ray.actor.ActorHandle, ray._raylet.ObjectRef]]:
+  
     if env is None:
       env = {}
 
     handles = []
+    tpu_head = f"TPU-{topology_id}-head"  
     for tpu in tpu_info:
-      
       if multislice:
         logging.info("Scheduling with multislice.")
         coordinator_port = 8081
@@ -159,6 +161,7 @@ class RayTpuManager:
 
   def _remote_device_mode(
       self,
+      topology_id: str, 
       actor_or_fn: Union[ray.actor.ActorClass, Type],
       tpu_info: List[Any],
       multislice = False,
@@ -220,7 +223,8 @@ class RayTpuManager:
 
     if device_mode:
         return self._remote_device_mode(
-          actor_or_fn,
+          topology_id,
+          actor_or_fn, 
           tpu_info,
           multislice,
           env,
@@ -228,6 +232,7 @@ class RayTpuManager:
           kwargs)
     else:
         return self._remote_host_mode(
+          topology_id,
           actor_or_fn,
           tpu_info,
           multislice,

--- a/src/ray_tpu.py
+++ b/src/ray_tpu.py
@@ -74,7 +74,7 @@ class RayTpuManager:
         )
     return tpu_info
 
-  def reserve(self, topology_id):
+  def reserve(self, topology_id, count):
     """
     This is a hacky way to reserve the topology. It utilizes Ray's
     existing ability to autoscale based on the "TPU-X-head" syntax
@@ -101,62 +101,23 @@ class RayTpuManager:
       remove_placement_group(pg)
 
     return tpu_info
-        
-  def remote(
+
+  def _remote_host_mode(
       self,
       actor_or_fn: Union[ray.actor.ActorClass, Type],
-      topology: Optional[Mapping[str, int]] = None,
+      tpu_info: List[Any],
       multislice = False,
       env: Optional[Mapping[str, Any]] = None,
       timeout: Optional[int] = 600,
       *args,
       **kwargs,
   ) -> List[Union[ray.actor.ActorHandle, ray._raylet.ObjectRef]]:
-    """Schedules an actor or function on a set of TPUs.
-
-    Args:
-        actor_or_fn: The definition of the actor, as a class or as a remote class, OR a function,
-            as a function or executable remote task.
-        topology: A dictionary representing the TPU topology, e.g. {"v6e-8": 1}
-        multislice: Whether or not to schedule this actor with multislice technology.
-            If set to true, this injects the metadata needed to schedule a multislice workload.
-            Else, this will be treated as individual pod slices.
-        env: An optional base environment, as a dictionary.
-        timeout: Timeout in seconds for placement group creation. Defaults to 600.
-
-    Returns:
-        A list of ActorHandles or ObjectRefs.
-    """
     if env is None:
       env = {}
 
-    if isinstance(actor_or_fn, type):
-      actor_or_fn = ray.remote(actor_or_fn)
-    elif callable(actor_or_fn):
-      if not hasattr(actor_or_fn, "remote"):
-        actor_or_fn = ray.remote(actor_or_fn)
-    elif not isinstance(actor_or_fn, ray.actor.ActorClass):
-      raise AssertionError(f"`actor_or_fn` should be a class definition, ActorClass, or callable, got {type(actor_or_fn)}")
-
     handles = []
-
-    if len(topology) > 1:
-      raise AssertionError("Only single topology types are supported")
-
-    topology_id, count = topology.popitem()
-
-    # topology_id is in the form "{generation}-{cores}".
-
-    tpu_info = self.reserve(topology_id)
+    for tpu in tpu_info:
       
-    time.sleep(1)
-
-    if len(tpu_info) != count:
-        raise AssertionError("Number of TPUs not equal to requested amount")
-
-    for i in range(count):
-      tpu = tpu_info[i]
-
       if multislice:
         logging.info("Scheduling with multislice.")
         coordinator_port = 8081
@@ -192,6 +153,87 @@ class RayTpuManager:
             actor_or_fn.options(resources={"TPU": tpu.chips_per_host, tpu.name: 1}).remote(*args, **kwargs) for _ in range(tpu.num_hosts - 1)
         ]
     return handles
+
+  def _remote_device_mode(
+      self,
+      actor_or_fn: Union[ray.actor.ActorClass, Type],
+      tpu_info: List[Any],
+      multislice = False,
+      env: Optional[Mapping[str, Any]] = None,
+      timeout: Optional[int] = 600,
+      *args,
+      **kwargs,
+  ) -> List[Union[ray.actor.ActorHandle, ray._raylet.ObjectRef]]:
+    # Not implemented 
+    pass
+
+  def remote(
+      self,
+      actor_or_fn: Union[ray.actor.ActorClass, Type],
+      topology: Optional[Mapping[str, int]] = None,
+      multislice = False,
+      device_mode = False,
+      env: Optional[Mapping[str, Any]] = None,
+      timeout: Optional[int] = 600,
+      *args,
+      **kwargs,
+  ) -> List[Union[ray.actor.ActorHandle, ray._raylet.ObjectRef]]:
+    """Schedules an actor or function on a set of TPUs.
+
+    Args:
+        actor_or_fn: The definition of the actor, as a class or as a remote class, OR a function,
+            as a function or executable remote task.
+        topology: A dictionary representing the TPU topology, e.g. {"v6e-8": 1}
+        multislice: Whether or not to schedule this actor with multislice technology.
+            If set to true, this injects the metadata needed to schedule a multislice workload.
+            Else, this will be treated as individual pod slices.
+        env: An optional base environment, as a dictionary.
+        timeout: Timeout in seconds for placement group creation. Defaults to 600.
+
+    Returns:
+        A list of ActorHandles or ObjectRefs.
+    """
+    if isinstance(actor_or_fn, type):
+      actor_or_fn = ray.remote(actor_or_fn)
+    elif callable(actor_or_fn):
+      if not hasattr(actor_or_fn, "remote"):
+        actor_or_fn = ray.remote(actor_or_fn)
+    elif not isinstance(actor_or_fn, ray.actor.ActorClass):
+      raise AssertionError(f"`actor_or_fn` should be a class definition, ActorClass, or callable, got {type(actor_or_fn)}")
+
+    if len(topology) > 1:
+      raise AssertionError("Only single topology types are supported")
+
+    topology_id, count = topology.popitem()
+
+    # topology_id is in the form "{generation}-{cores}".
+    # count is how many instances of each topology to create.
+
+    tpu_info = self.reserve(topology_id, count)
+      
+    time.sleep(1)
+
+    if len(tpu_info) != count:
+        raise AssertionError("Number of TPUs not equal to requested amount")
+
+    if device_mode:
+        return self._remote_device_mode(
+          actor_or_fn,
+          tpu_info,
+          multislice,
+          env,
+          timeout,
+          args,
+          kwargs)
+    else:
+        return self._remote_host_mode(
+          actor_or_fn,
+          tpu_info,
+          multislice,
+          env,
+          timeout,
+          args,
+          kwargs)        
 
 
 _manager = RayTpuManager()


### PR DESCRIPTION
This PR did a few refactors:
* Create a `reserve` function for creating the placement group
* Split `remote` into `remote_host_mode` and `remote_device_mode` (the latter is not yet implemented)